### PR TITLE
Provide a clean way to check whether a property is defined

### DIFF
--- a/_setup/4.type/1.type.js
+++ b/_setup/4.type/1.type.js
@@ -363,6 +363,12 @@ module.exports = function (db, createObj, object) {
 		resolveSKeyPath: d(function (sKeyPath, _observe) {
 			return resolveSKeyPath(this, sKeyPath, _observe);
 		}),
+		hasOwnPropertyDefined: d(function (key) {
+			return this.getDescriptor(key).object === this;
+		}),
+		hasPropertyDefined: d(function (key) {
+			return this.getDescriptor(key).__id__ !== '$';
+		}),
 		stringifyPropertyValue: d(function (key) {
 			var desc = this.getDescriptor(key)
 			  , value = this.get(key);

--- a/test/_setup/4.type/1.type.js
+++ b/test/_setup/4.type/1.type.js
@@ -338,6 +338,28 @@ module.exports = function (a) {
 			a(db.Submission.prototype.document.constructor, db.Document);
 			a(db.User.prototype.submissions.someSubmission.document.constructor, db.Dui);
 		},
+		"Propery definition check": function (a) {
+			var db = new Database(), process, specificProcess;
+			db.Object.extend('Process', {
+				propertyOnProcess: { type: db.Number }
+			});
+			db.Process.extend('SpecificProcess', {
+				propertyOnSpecificProcess: { type: db.Number }
+			});
+			process = new db.Process();
+			a(process.hasOwnPropertyDefined('propertyOnProcess'), false);
+			a(process.hasPropertyDefined('propertyOnProcess'), true);
+			a(process.hasOwnPropertyDefined('propertyOnSpecificProcess'), false);
+			a(process.hasPropertyDefined('propertyOnSpecificProcess'), false);
+			specificProcess = new db.SpecificProcess({
+				propertyOnProcess: 42,
+				propertyOnSpecificProcess: 24
+			});
+			a(specificProcess.hasOwnPropertyDefined('propertyOnProcess'), true);
+			a(specificProcess.hasPropertyDefined('propertyOnProcess'), true);
+			a(specificProcess.hasOwnPropertyDefined('propertyOnSpecificProcess'), true);
+			a(specificProcess.hasPropertyDefined('propertyOnSpecificProcess'), true);
+		},
 		"Stringify type": function (a) {
 			var db = new Database(), obj;
 			db.Number.extend('NumberExt', {}, { toString: { value: function (options) {


### PR DESCRIPTION
/cc @mtuchowski

In ECMAScript property definition come together with property set (there's no way to define property but do not provide any value). While in DBJS definition concept is separate of set concept, therefore we can't use ECMAScript means (as `hasOwnProperty` or `'x' in obj`) to check wether property was defined.

At this point the way to check wether property has _own_ definition is: `object.getDescriptor('propName').object === object`, and whether it has defintion at all is: `object.getDescriptor('propName').__id__ !== '$'`. This is far from being intuitive. 

`hasOwnPropertyDefined` and `hasPropertyDefined` should be introduced for this cases.